### PR TITLE
Make multichain service configurable

### DIFF
--- a/charts/multichain-node/README.md
+++ b/charts/multichain-node/README.md
@@ -29,6 +29,9 @@ A Helm chart for the SensRNet multichain node
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.externalTrafficPolicy | string | `"Cluster"` |  |
+| service.type | string | `"ClusterIP"` |  |
 | settings.chainName | string | `"SensRNet"` |  |
 | settings.connectToExistingChain | bool | `false` |  |
 | settings.mainNodeHost | string | `"1.2.3.4"` |  |

--- a/charts/multichain-node/templates/service.yaml
+++ b/charts/multichain-node/templates/service.yaml
@@ -13,6 +13,7 @@ spec:
   {{- if .Values.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
   ports:
     - name: rpc
       port: {{ .Values.settings.rpc.port }}

--- a/charts/multichain-node/templates/service.yaml
+++ b/charts/multichain-node/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "multichain-node.fullname" . }}
   labels:
     {{- include "multichain-node.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/multichain-node/templates/service.yaml
+++ b/charts/multichain-node/templates/service.yaml
@@ -4,7 +4,15 @@ metadata:
   name: {{ include "multichain-node.fullname" . }}
   labels:
     {{- include "multichain-node.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - name: rpc
       port: {{ .Values.settings.rpc.port }}

--- a/charts/multichain-node/values.yaml
+++ b/charts/multichain-node/values.yaml
@@ -31,6 +31,7 @@ securityContext: {}
 service:
   type: ClusterIP
   annotations: {}
+  externalTrafficPolicy: Cluster
 
 ingress:
   enabled: true

--- a/charts/multichain-node/values.yaml
+++ b/charts/multichain-node/values.yaml
@@ -28,6 +28,10 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+service:
+  type: ClusterIP
+  annotations: {}
+
 ingress:
   enabled: true
   annotations:


### PR DESCRIPTION
Multichain node currently always uses a cluster ip, assuming traffic routing via Traefik. However, in some instances it might be required to acquired its own dedicated public IP. For this reason, make Service configurable, so that operators can specify it as type LoadBalancer