### PR TITLE
make ingress route hosts configurable

### DIFF
--- a/charts/multichain-node/README.md
+++ b/charts/multichain-node/README.md
@@ -1,6 +1,6 @@
 # multichain-node
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.1](https://img.shields.io/badge/AppVersion-0.1.1-informational?style=flat-square)
 
 A Helm chart for the SensRNet multichain node
 
@@ -20,8 +20,7 @@ A Helm chart for the SensRNet multichain node
 | image.repository | string | `"sensrnetnl/multichain-node"` |  |
 | ingress.annotations."kubernetes.io/ingress.class" | string | `"traefik"` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.routes[0].match | string | `"HostSNI(`*`)"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/multichain-node/templates/ingress-tcp.yaml
+++ b/charts/multichain-node/templates/ingress-tcp.yaml
@@ -14,9 +14,11 @@ spec:
   entryPoints:
   - multichain
   routes:
-  - match: HostSNI(`*`)
-    kind: Rule
-    services:
-    - name: {{ $fullName }}
-      port: {{ .Values.settings.p2pPort }}
+    {{- range .Values.ingress.routes }}
+    - kind: Rule
+      match: {{ .match | quote }}
+      services:
+      - name: {{ $fullName }}
+        port: {{ .Values.settings.p2pPort }}
+    {{- end }}
 {{- end }}

--- a/charts/multichain-node/values.yaml
+++ b/charts/multichain-node/values.yaml
@@ -38,9 +38,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: traefik
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths: []
+  routes:
+    - match: HostSNI(`*`)
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/registry-backend/README.md
+++ b/charts/registry-backend/README.md
@@ -43,8 +43,7 @@ A Helm chart for the SensRNet registry back-end
 | image.repository | string | `"sensrnetnl/registry-backend"` |  |
 | ingress.annotations."kubernetes.io/ingress.class" | string | `"traefik"` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.routes[0].match | string | `"PathPrefix(`/api/`)"` |  |
 | ingress.tls | list | `[]` |  |
 | mongodb.architecture | string | `"replicaset"` |  |
 | mongodb.auth.enabled | bool | `false` |  |

--- a/charts/registry-backend/templates/deployment.yaml
+++ b/charts/registry-backend/templates/deployment.yaml
@@ -24,17 +24,17 @@ spec:
           - name: EVENT_STORE_HOST
             value: {{ .Values.settings.eventstore.host }}
           - name: EVENT_STORE_PORT
-            value: "{{ .Values.settings.eventstore.port }}"
+            value: {{ .Values.settings.eventstore.port | quote }}
           - name: JWT_SECRET
             value: {{ .Values.settings.jwtSecret }}
           - name: JWT_ACCESS_EXPIRES_IN
-            value: "{{ .Values.settings.jwtAccessExpiresIn }}"
+            value: {{ .Values.settings.jwtAccessExpiresIn | quote }}
           - name: JWT_REFRESH_EXPIRES_IN
-            value: "{{ .Values.settings.jwtRefreshExpiresIn }}"
+            value: {{ .Values.settings.jwtRefreshExpiresIn | quote }}
           - name: MONGO_HOST
             value: {{ .Values.settings.mongo.host }}
           - name: MONGO_PORT
-            value: "{{ .Values.settings.mongo.port }}"
+            value: {{ .Values.settings.mongo.port | quote }}
           - name: MONGO_DATABASE
             value: {{ .Values.settings.mongo.database }}
           ports:

--- a/charts/registry-backend/templates/ingress.yaml
+++ b/charts/registry-backend/templates/ingress.yaml
@@ -14,8 +14,9 @@ spec:
   entryPoints:
   - web
   routes:
+    {{- range .Values.ingress.routes }}
   - kind: Rule
-    match: PathPrefix(`/api/`)
+    match: {{ .match | quote }}
     services:
     - kind: Service
       name: {{ $fullName }}
@@ -23,3 +24,4 @@ spec:
       sticky:
         cookie:
           httpOnly: true
+    {{- end}}

--- a/charts/registry-backend/values.yaml
+++ b/charts/registry-backend/values.yaml
@@ -83,9 +83,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: traefik
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths: []
+  routes:
+    - match: PathPrefix(`/api/`)
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/charts/registry-frontend/README.md
+++ b/charts/registry-frontend/README.md
@@ -20,8 +20,7 @@ A Helm chart for Kubernetes
 | image.repository | string | `"sensrnetnl/registry-frontend"` |  |
 | ingress.annotations."kubernetes.io/ingress.class" | string | `"traefik"` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.routes[0].match | string | `"PathPrefix(`/`)"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/registry-frontend/templates/ingress.yaml
+++ b/charts/registry-frontend/templates/ingress.yaml
@@ -15,10 +15,12 @@ spec:
   entryPoints:
     - web
   routes:
+    {{- range .Values.ingress.routes }}
     - kind: Rule
-      match: PathPrefix(`/`)
+      match: {{ .match | quote }}
       services:
         - kind: Service
           name: {{ $fullName }}
           port: {{ $svcPort }}
+    {{- end}}
 {{- end }}

--- a/charts/registry-frontend/values.yaml
+++ b/charts/registry-frontend/values.yaml
@@ -30,9 +30,8 @@ ingress:
   annotations:
     kubernetes.io/ingress.class: traefik
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths: []
+  routes:
+    - match: PathPrefix(`/`)
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
Uitbreiding van Helm charts om Ingress route hosts aan te kunnen passen. Hiermee kunnen we routes configureren voor verschillende DNS names / namespaces (demo, viewer)

Voorbeeld:
```
helm upgrade --install registry-backend charts/registry-backend/ \
  --set ingress.routes[0].match="Host(\`demo.example.org\`) && PathPrefix(\`/api\`)"
```