### PR TITLE
Update ingresses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
-    hooks:
-      - id: trailing-whitespace
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.12
     hooks:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ kubectl create namespace sensrnet-registry
 ```
 
 ### TCP traffic for multichain node
-One of the components, the multichain node, requires an TCP ingress. It requires an TCP ingress, which is not natively supported by Kubernetes. We currently make use of Traefik v2's IngressRouteTCP CRD, which enables the use of TCP routes. This means we assume Traefik v2 as Ingress Controller with port 8571 exposed. We're looking into supporting Nginx as well, but is currently not supported in this Chart.
+One of the components, the multichain node, requires an TCP ingress. It requires an TCP ingress. This is not natively supported by Kubernetes. We currently make use of Traefik v2's IngressRouteTCP CRD, which enables the use of TCP routes. This means we assume Traefik v2 as Ingress Controller with port 8571 exposed. We're looking into supporting Nginx as well, but is currently not supported in this Chart.
 
 The routes are of the Traefik IngressRoute form, for example:
 ```ingress.routes[0].match=HostSNI(`*`)```. This is now set as default, the routing is actually done via the Entrypoint, which is the named exposed port in the Traefik v2 Ingress Controller. More information on IngressRouteTCP can be found [here](https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/#kind-ingressroutetcp).

--- a/charts/central-viewer-geoserver/Chart.yaml
+++ b/charts/central-viewer-geoserver/Chart.yaml
@@ -12,4 +12,4 @@ name: central-viewer-geoserver
 sources:
   - https://github.com/kadaster-labs/sensrnet-central-viewer-geoserver
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/charts/central-viewer-geoserver/README.md
+++ b/charts/central-viewer-geoserver/README.md
@@ -1,6 +1,6 @@
 # central-viewer-geoserver
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 A Helm chart for the central viewer geoserver of SensRNet
 
@@ -19,9 +19,10 @@ A Helm chart for the central viewer geoserver of SensRNet
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"sensrnetnl/central-viewer-geoserver"` |  |
 | image.tag | string | `""` |  |
-| ingress.annotations."kubernetes.io/ingress.class" | string | `"traefik"` |  |
+| ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.routes[0].match | string | `"PathPrefix(`/geoserver`)"` |  |
+| ingress.host | string | `"central-viewer.localhost"` |  |
+| ingress.path | string | `"/geoserver"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/central-viewer-geoserver/templates/ingress.yaml
+++ b/charts/central-viewer-geoserver/templates/ingress.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "central-viewer-geoserver.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
@@ -12,15 +16,22 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  entryPoints:
-    - web
-  routes:
-    {{- range .Values.ingress.routes }}
-    - kind: Rule
-      match: {{ .match | quote }}
-      services:
-        - kind: Service
-          name: {{ $fullName }}
-          port: {{ $svcPort }}
-    {{- end}}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}

--- a/charts/central-viewer-geoserver/values.schema.json
+++ b/charts/central-viewer-geoserver/values.schema.json
@@ -26,26 +26,16 @@
             "type": "object",
             "properties": {
                 "annotations": {
-                    "type": "object",
-                    "properties": {
-                        "kubernetes.io/ingress.class": {
-                            "type": "string"
-                        }
-                    }
+                    "type": "object"
                 },
                 "enabled": {
                     "type": "boolean"
                 },
-                "routes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "match": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                "host": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
                 },
                 "tls": {
                     "type": "array"

--- a/charts/central-viewer-geoserver/values.yaml
+++ b/charts/central-viewer-geoserver/values.yaml
@@ -26,10 +26,9 @@ service:
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: traefik
-  routes:
-    - match: PathPrefix(`/geoserver`)
+  annotations: {}
+  host: central-viewer.localhost
+  path: /geoserver
   tls: []
 
 resources: {}

--- a/charts/central-viewer/Chart.yaml
+++ b/charts/central-viewer/Chart.yaml
@@ -12,4 +12,4 @@ name: central-viewer
 sources:
   - https://github.com/kadaster-labs/sensrnet-central-viewer
 type: application
-version: 0.2.1
+version: 0.2.2

--- a/charts/central-viewer/README.md
+++ b/charts/central-viewer/README.md
@@ -1,6 +1,6 @@
 # central-viewer
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 A Helm chart for the central viewer of SensRNet
 
@@ -19,9 +19,9 @@ A Helm chart for the central viewer of SensRNet
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"sensrnetnl/central-viewer"` |  |
 | image.tag | string | `""` |  |
-| ingress.annotations."kubernetes.io/ingress.class" | string | `"traefik"` |  |
+| ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.routes[0].match | string | `"PathPrefix(`/`)"` |  |
+| ingress.host | string | `"central-viewer.local"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/central-viewer/templates/ingress.yaml
+++ b/charts/central-viewer/templates/ingress.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "central-viewer.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
@@ -12,15 +16,22 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  entryPoints:
-    - web
-  routes:
-    {{- range .Values.ingress.routes }}
-    - kind: Rule
-      match: {{ .match | quote }}
-      services:
-        - kind: Service
-          name: {{ $fullName }}
-          port: {{ $svcPort }}
-    {{- end}}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}

--- a/charts/central-viewer/values.schema.json
+++ b/charts/central-viewer/values.schema.json
@@ -26,26 +26,13 @@
             "type": "object",
             "properties": {
                 "annotations": {
-                    "type": "object",
-                    "properties": {
-                        "kubernetes.io/ingress.class": {
-                            "type": "string"
-                        }
-                    }
+                    "type": "object"
                 },
                 "enabled": {
                     "type": "boolean"
                 },
-                "routes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "match": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                "host": {
+                    "type": "string"
                 },
                 "tls": {
                     "type": "array"

--- a/charts/central-viewer/values.yaml
+++ b/charts/central-viewer/values.yaml
@@ -20,10 +20,8 @@ service:
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: traefik
-  routes:
-    - match: PathPrefix(`/`)
+  annotations: {}
+  host: central-viewer.local
   tls: []
 
 resources: {}

--- a/charts/multichain-node/Chart.yaml
+++ b/charts/multichain-node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: 0.2.0
-description: A Helm chart for the SensRNet multichain node
+description: Instructions for installation can be found at https://github.com/kadaster-labs/sensrnet-helm-charts#tcp-traffic-for-multichain-node
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
 keywords:

--- a/charts/multichain-node/README.md
+++ b/charts/multichain-node/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
-A Helm chart for the SensRNet multichain node
+Instructions for installation can be found at https://github.com/kadaster-labs/sensrnet-helm-charts#tcp-traffic-for-multichain-node
 
 **Homepage:** <https://github.com/kadaster-labs/sensrnet-home>
 

--- a/charts/registry-backend/Chart.yaml
+++ b/charts/registry-backend/Chart.yaml
@@ -21,4 +21,4 @@ name: registry-backend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-backend
 type: application
-version: 0.3.2
+version: 0.3.3

--- a/charts/registry-backend/README.md
+++ b/charts/registry-backend/README.md
@@ -1,6 +1,6 @@
 # registry-backend
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 A Helm chart for the SensRNet registry back-end
 
@@ -45,9 +45,10 @@ A Helm chart for the SensRNet registry back-end
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"sensrnetnl/registry-backend"` |  |
 | image.tag | string | `""` |  |
-| ingress.annotations."kubernetes.io/ingress.class" | string | `"traefik"` |  |
+| ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.routes[0].match | string | `"PathPrefix(`/api/`)"` |  |
+| ingress.host | string | `"sensrnet.local"` |  |
+| ingress.path | string | `"/api"` |  |
 | ingress.tls | list | `[]` |  |
 | mongodb.architecture | string | `"replicaset"` |  |
 | mongodb.auth.enabled | bool | `false` |  |

--- a/charts/registry-backend/templates/ingress.yaml
+++ b/charts/registry-backend/templates/ingress.yaml
@@ -1,7 +1,12 @@
+{{- if .Values.ingress.enabled -}}
 {{- $fullName := include "registry-backend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
@@ -11,17 +16,22 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  entryPoints:
-  - web
-  routes:
-    {{- range .Values.ingress.routes }}
-  - kind: Rule
-    match: {{ .match | quote }}
-    services:
-    - kind: Service
-      name: {{ $fullName }}
-      port: {{ $svcPort }}
-      sticky:
-        cookie:
-          httpOnly: true
-    {{- end}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}

--- a/charts/registry-backend/values.schema.json
+++ b/charts/registry-backend/values.schema.json
@@ -128,26 +128,16 @@
             "type": "object",
             "properties": {
                 "annotations": {
-                    "type": "object",
-                    "properties": {
-                        "kubernetes.io/ingress.class": {
-                            "type": "string"
-                        }
-                    }
+                    "type": "object"
                 },
                 "enabled": {
                     "type": "boolean"
                 },
-                "routes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "match": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                "host": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
                 },
                 "tls": {
                     "type": "array"

--- a/charts/registry-backend/values.yaml
+++ b/charts/registry-backend/values.yaml
@@ -86,10 +86,9 @@ service:
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: traefik
-  routes:
-    - match: PathPrefix(`/api/`)
+  annotations: {}
+  host: sensrnet.local
+  path: /api
   tls: []
 
 resources: {}

--- a/charts/registry-frontend/Chart.yaml
+++ b/charts/registry-frontend/Chart.yaml
@@ -12,4 +12,4 @@ name: registry-frontend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-frontend
 type: application
-version: 0.3.2
+version: 0.3.3

--- a/charts/registry-frontend/README.md
+++ b/charts/registry-frontend/README.md
@@ -1,6 +1,6 @@
 # registry-frontend
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
+![Version: 0.3.3](https://img.shields.io/badge/Version-0.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.5.0](https://img.shields.io/badge/AppVersion-0.5.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 
@@ -19,9 +19,9 @@ A Helm chart for Kubernetes
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"sensrnetnl/registry-frontend"` |  |
 | image.tag | string | `""` |  |
-| ingress.annotations."kubernetes.io/ingress.class" | string | `"traefik"` |  |
+| ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
-| ingress.routes[0].match | string | `"PathPrefix(`/`)"` |  |
+| ingress.host | string | `"sensrnet.local"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/registry-frontend/templates/ingress.yaml
+++ b/charts/registry-frontend/templates/ingress.yaml
@@ -1,8 +1,12 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "registry-frontend.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
@@ -12,15 +16,22 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  entryPoints:
-    - web
-  routes:
-    {{- range .Values.ingress.routes }}
-    - kind: Rule
-      match: {{ .match | quote }}
-      services:
-        - kind: Service
-          name: {{ $fullName }}
-          port: {{ $svcPort }}
-    {{- end}}
-{{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}

--- a/charts/registry-frontend/values.schema.json
+++ b/charts/registry-frontend/values.schema.json
@@ -26,26 +26,13 @@
             "type": "object",
             "properties": {
                 "annotations": {
-                    "type": "object",
-                    "properties": {
-                        "kubernetes.io/ingress.class": {
-                            "type": "string"
-                        }
-                    }
+                    "type": "object"
                 },
                 "enabled": {
                     "type": "boolean"
                 },
-                "routes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "match": {
-                                "type": "string"
-                            }
-                        }
-                    }
+                "host": {
+                    "type": "string"
                 },
                 "tls": {
                     "type": "array"

--- a/charts/registry-frontend/values.yaml
+++ b/charts/registry-frontend/values.yaml
@@ -22,10 +22,8 @@ service:
 
 ingress:
   enabled: true
-  annotations:
-    kubernetes.io/ingress.class: traefik
-  routes:
-    - match: PathPrefix(`/`)
+  annotations: {}
+  host: sensrnet.local
   tls: []
 
 resources: {}


### PR DESCRIPTION
Alle `Ingress`s maakten gebruik van Traefik Custom Resource Definitions, terwijl dat momenteel alleen nodig is voor multichain. Gezien Traefik ook prima de standaard `Ingress` oppakt, kunnen we de overige componenten (frontend, viewer, geoserver en backend) beter omschrijven naar `Ingress`, ipv `IngressRoute`. Hiervoor zijn de `ingress.yml`s en `values.yml`s aangepast. De Readme's en values.schema.json reflecteren deze wijziging.

Er bestond nog wat onduidelijkheid over hoe de multichain te installeren. Instructies hiervoor heb ik toegevoegd in de top-level README.md, met een verwijzing in de `charts/multichain-node/README.md`, om de instructies voor installatie zoveel mogelijk bijeen te houden.

Multichain-node heeft, vanwege de niet-natively ondersteunde TCP route, nog steeds extra's nodig. In ons geval is dat nu Traefik v2's IngressRouteTCP, maar dat kan ook met extra configfiles voor Nginx gedaan worden. De keuze hiervoor hangt af van de IngressController die gebruikt wordt op het cluster. Implementerende partijen worden nu verplicht Traefik te gebruiken, we kunnen dus overwegen om ook deployment files voor nginx toe te voegen, als alternatief naast traefik. 