### PR TITLE
add parameters to MultiChain Chart

### DIFF
--- a/charts/multichain-node/templates/statefulset.yaml
+++ b/charts/multichain-node/templates/statefulset.yaml
@@ -48,6 +48,12 @@ spec:
               value: "anyone-can-connect|true"
             - name: PARAM_ANYONE_CAN_MINE
               value: "anyone-can-mine|true"
+            - name: PARAM_PRIVATE_KEY_VERSION
+              value: "private-key-version|80ea7b28"
+            - name: PARAM_ADDRESS_CHECKSUM_VALUE
+              value: "address-checksum-value|344cbb15"
+            - name: PARAM_ADDRESS_PUBKEYHASH_VERSION
+              value: "address-pubkeyhash-version|00f7391c"
             {{ end }}
             {{ if .Values.settings.privateKey }}
             - name: PRIVATE_KEY


### PR DESCRIPTION
Deze stonden nog niet in de chart. In principe alleen relevant voor de creatie van de chain, de eerste run op de master node. Voor de volledigheid en mochten we zelf onze eigen chain moeten resetten oid 😉 Heb 'm niet aan de values toegevoegd, gezien operators ze niet hoeven te overschrijven. Daarvoor kunnen ze het generate_keypair.js scriptje voor gebruiken