### PR TITLE
chore: Bump app versions

### DIFF
--- a/charts/central-viewer-geoserver/Chart.yaml
+++ b/charts/central-viewer-geoserver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.2.1
+appVersion: 0.2.2
 description: A Helm chart for the central viewer geoserver of SensRNet
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: central-viewer-geoserver
 sources:
   - https://github.com/kadaster-labs/sensrnet-central-viewer-geoserver
 type: application
-version: 0.2.3
+version: 0.2.4

--- a/charts/central-viewer-geoserver/README.md
+++ b/charts/central-viewer-geoserver/README.md
@@ -1,6 +1,6 @@
 # central-viewer-geoserver
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.1](https://img.shields.io/badge/AppVersion-0.2.1-informational?style=flat-square)
+![Version: 0.2.4](https://img.shields.io/badge/Version-0.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
 
 A Helm chart for the central viewer geoserver of SensRNet
 

--- a/charts/central-viewer/Chart.yaml
+++ b/charts/central-viewer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.6.3
+appVersion: 0.6.4
 description: A Helm chart for the central viewer of SensRNet
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: central-viewer
 sources:
   - https://github.com/kadaster-labs/sensrnet-central-viewer
 type: application
-version: 0.4.1
+version: 0.4.2

--- a/charts/central-viewer/README.md
+++ b/charts/central-viewer/README.md
@@ -1,6 +1,6 @@
 # central-viewer
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.3](https://img.shields.io/badge/AppVersion-0.6.3-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.4](https://img.shields.io/badge/AppVersion-0.6.4-informational?style=flat-square)
 
 A Helm chart for the central viewer of SensRNet
 

--- a/charts/registry-backend/Chart.yaml
+++ b/charts/registry-backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.6.0
+appVersion: 0.7.0
 dependencies:
   - name: mongodb
     version: "10.6.0"
@@ -21,4 +21,4 @@ name: registry-backend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-backend
 type: application
-version: 0.5.0
+version: 0.6.0

--- a/charts/registry-backend/README.md
+++ b/charts/registry-backend/README.md
@@ -1,6 +1,6 @@
 # registry-backend
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.0](https://img.shields.io/badge/AppVersion-0.6.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Helm charts for the SensRNet registry back-end
 

--- a/charts/registry-frontend/Chart.yaml
+++ b/charts/registry-frontend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.0
+appVersion: 0.9.1
 description: A Helm chart for Kubernetes
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: registry-frontend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-frontend
 type: application
-version: 0.6.0
+version: 0.6.1

--- a/charts/registry-frontend/README.md
+++ b/charts/registry-frontend/README.md
@@ -1,6 +1,6 @@
 # registry-frontend
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.1](https://img.shields.io/badge/AppVersion-0.9.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/sync-bridge/Chart.yaml
+++ b/charts/sync-bridge/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.3.0
+appVersion: 0.3.1
 description: A Helm chart for the SensRNet sync component between SensRNet registry back-end and MultiChain node
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: sync-bridge
 sources:
   - https://github.com/kadaster-labs/sensrnet-sync
 type: application
-version: 0.3.0
+version: 0.3.1

--- a/charts/sync-bridge/README.md
+++ b/charts/sync-bridge/README.md
@@ -1,6 +1,6 @@
 # sync-bridge
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
 
 A Helm chart for the SensRNet sync component between SensRNet registry back-end and MultiChain node
 


### PR DESCRIPTION
Bump central-viewer from 0.4.1 to 0.4.2
Bump central-viewer-geoserver from 0.2.3 to 0.2.4
Bump registry-backend from 0.5.0 to 0.6.0
Bump registry-frontend from 0.6.0 to 0.6.1
Bump sync-bridge from 0.3.0 to 0.3.1