### PR TITLE
feat: run central-viewer under some path

### DIFF
--- a/charts/central-viewer/README.md
+++ b/charts/central-viewer/README.md
@@ -22,6 +22,7 @@ A Helm chart for the central viewer of SensRNet
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `true` |  |
 | ingress.host | string | `"central-viewer.local"` |  |
+| ingress.path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/central-viewer/templates/deployment.yaml
+++ b/charts/central-viewer/templates/deployment.yaml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: GEOSERVER_URL
               value: {{ .Values.settings.geoserverUrl }}
+            - name: BASE_HREF
+              value: {{ .Values.ingress.path }}
           args:
             - -health-status=true
           ports:

--- a/charts/central-viewer/templates/ingress.yaml
+++ b/charts/central-viewer/templates/ingress.yaml
@@ -30,7 +30,7 @@ spec:
     - host: {{ .Values.ingress.host | quote }}
       http:
         paths:
-          - path: /
+          - path: {{ .Values.ingress.path }}
             {{- if semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion }}
             pathType: Prefix
             {{- end }}

--- a/charts/central-viewer/values.yaml
+++ b/charts/central-viewer/values.yaml
@@ -22,6 +22,7 @@ ingress:
   enabled: true
   annotations: {}
   host: central-viewer.local
+  path: /
   tls: []
 
 resources: {}


### PR DESCRIPTION
... by setting the Ingress and passing an environment variable

Can be tested by using a local K8s cluster (e.g. from Docker Desktop) and the updated script from https://github.com/kadaster-labs/sensrnet-ops/pull/44

Links to https://github.com/kadaster-labs/sensrnet-central-viewer/issues/49