### PR TITLE
chore: Bump component versions

### DIFF
--- a/charts/registry-backend/Chart.yaml
+++ b/charts/registry-backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.7.1
+appVersion: 0.8.1
 dependencies:
   - name: mongodb
     version: "10.6.0"
@@ -21,4 +21,4 @@ name: registry-backend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-backend
 type: application
-version: 0.6.2
+version: 0.6.3

--- a/charts/registry-backend/README.md
+++ b/charts/registry-backend/README.md
@@ -1,6 +1,6 @@
 # registry-backend
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
 
 Helm charts for the SensRNet registry back-end
 

--- a/charts/registry-frontend/Chart.yaml
+++ b/charts/registry-frontend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.1
+appVersion: 0.10.1
 description: A Helm chart for Kubernetes
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: registry-frontend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-frontend
 type: application
-version: 0.6.2
+version: 0.6.3

--- a/charts/registry-frontend/README.md
+++ b/charts/registry-frontend/README.md
@@ -1,6 +1,6 @@
 # registry-frontend
 
-![Version: 0.6.2](https://img.shields.io/badge/Version-0.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.1](https://img.shields.io/badge/AppVersion-0.9.1-informational?style=flat-square)
+![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
chore: Bump registry-backend from 0.7.1 to 0.8.1 

- A observed-area is saved as polygon (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/140)
- Bugfix to fix that location-description keys are overwritten (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/144)
- Validate the body of the unit-of-measurement. For now it must contain a name, and a symbol (see the sensorthingapi standard) (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/145)
- Return 404 when resource not found. Relevant for Devices and ObservationGoals (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/147)

chore: Bump registry-frontend from 0.9.1 to 0.10.1 

- Implemented draw functionality for both location and observed area (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/191)
- Add unit-of-measurement to datastream (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/193)
- Fix sensor type validation UI (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/196)
- Prevent multiple identical devices (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/197)