### PR TITLE
MongoDB migraties uitvoeren tijdens helm upgrade

### DIFF
--- a/charts/registry-backend/templates/job.yaml
+++ b/charts/registry-backend/templates/job.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ include "registry-backend.fullname" . }}-migration
   labels:
   annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     spec:

--- a/charts/registry-backend/templates/job.yaml
+++ b/charts/registry-backend/templates/job.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.settings.migrate }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "registry-backend.fullname" . }}
+  labels:
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{ .Chart.Name }}-migration
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MONGO_HOST
+              value: {{ .Values.settings.mongo.host }}
+            - name: MONGO_PORT
+              value: {{ .Values.settings.mongo.port | quote }}
+            - name: MONGO_DATABASE
+              value: {{ .Values.settings.mongo.database }}
+          args: [ 'migrate' ]
+      initContainers:
+        - name: check-mongo-ready
+          image: mongo:4.4.3
+          command: [ 'sh', '-c',
+              'until mongo --host {{ .Values.settings.mongo.host }}:27017 --eval "printjson(db.serverStatus())";
+                  do echo waiting for mongo; sleep 10; done;' ]
+{{- end }}

--- a/charts/registry-backend/templates/job.yaml
+++ b/charts/registry-backend/templates/job.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
 spec:
   template:
     spec:

--- a/charts/registry-backend/templates/job.yaml
+++ b/charts/registry-backend/templates/job.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.settings.migrate }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,4 +29,3 @@ spec:
           command: [ 'sh', '-c',
               'until mongo --host {{ .Values.settings.mongo.host }}:27017 --eval "printjson(db.serverStatus())";
                   do echo waiting for mongo; sleep 10; done;' ]
-{{- end }}

--- a/charts/registry-backend/templates/job.yaml
+++ b/charts/registry-backend/templates/job.yaml
@@ -3,16 +3,17 @@ kind: Job
 metadata:
   name: {{ include "registry-backend.fullname" . }}-migration
   labels:
+    {{- include "registry-backend.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install,pre-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     spec:
       restartPolicy: Never
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}-migration
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:

--- a/charts/registry-backend/templates/job.yaml
+++ b/charts/registry-backend/templates/job.yaml
@@ -2,18 +2,17 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "registry-backend.fullname" . }}
+  name: {{ include "registry-backend.fullname" . }}-migration
   labels:
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
 spec:
   template:
     spec:
       restartPolicy: Never
       containers:
-        - name: {{ .Chart.Name }}-migration
+        - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: IfNotPresent
           env:

--- a/charts/registry-backend/values.yaml
+++ b/charts/registry-backend/values.yaml
@@ -10,7 +10,7 @@ fullnameOverride: ""
 
 
 settings:
-  migrate: false
+  migrate: true
   requireAuthentication: true
   oidc_issuer: ""
   oidc_jwks_url: ""

--- a/charts/registry-backend/values.yaml
+++ b/charts/registry-backend/values.yaml
@@ -10,7 +10,6 @@ fullnameOverride: ""
 
 
 settings:
-  migrate: true
   requireAuthentication: true
   oidc_issuer: ""
   oidc_jwks_url: ""

--- a/charts/registry-backend/values.yaml
+++ b/charts/registry-backend/values.yaml
@@ -10,6 +10,7 @@ fullnameOverride: ""
 
 
 settings:
+  migrate: false
   requireAuthentication: true
   oidc_issuer: ""
   oidc_jwks_url: ""


### PR DESCRIPTION
Toevoegen van een job, die de nog-niet uitgevoerde mongoDB migraties uitvoert. Deze wordt uitgevoerd na een helm install / upgrade van de backend, door middel van een helm hook.