### PR TITLE
chore: Bump component versions

### DIFF
--- a/charts/central-viewer/Chart.yaml
+++ b/charts/central-viewer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.6.4
+appVersion: 0.6.6
 description: A Helm chart for the central viewer of SensRNet
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: central-viewer
 sources:
   - https://github.com/kadaster-labs/sensrnet-central-viewer
 type: application
-version: 0.4.3
+version: 0.4.4

--- a/charts/central-viewer/README.md
+++ b/charts/central-viewer/README.md
@@ -1,6 +1,6 @@
 # central-viewer
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.4](https://img.shields.io/badge/AppVersion-0.6.4-informational?style=flat-square)
+![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
 
 A Helm chart for the central viewer of SensRNet
 

--- a/charts/registry-backend/Chart.yaml
+++ b/charts/registry-backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.8.1
+appVersion: 0.9.0
 dependencies:
   - name: mongodb
     version: "10.6.0"
@@ -21,4 +21,4 @@ name: registry-backend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-backend
 type: application
-version: 0.6.3
+version: 0.6.4

--- a/charts/registry-backend/README.md
+++ b/charts/registry-backend/README.md
@@ -1,6 +1,6 @@
 # registry-backend
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.1](https://img.shields.io/badge/AppVersion-0.8.1-informational?style=flat-square)
+![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
 
 Helm charts for the SensRNet registry back-end
 

--- a/charts/registry-frontend/Chart.yaml
+++ b/charts/registry-frontend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.10.1
+appVersion: 0.11.0
 description: A Helm chart for Kubernetes
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: registry-frontend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-frontend
 type: application
-version: 0.6.3
+version: 0.6.4

--- a/charts/registry-frontend/README.md
+++ b/charts/registry-frontend/README.md
@@ -1,6 +1,6 @@
 # registry-frontend
 
-![Version: 0.6.3](https://img.shields.io/badge/Version-0.6.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.10.1](https://img.shields.io/badge/AppVersion-0.10.1-informational?style=flat-square)
+![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/sync-bridge/Chart.yaml
+++ b/charts/sync-bridge/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.3.1
+appVersion: 0.4.0
 description: A Helm chart for the SensRNet sync component between SensRNet registry back-end and MultiChain node
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: sync-bridge
 sources:
   - https://github.com/kadaster-labs/sensrnet-sync
 type: application
-version: 0.3.1
+version: 0.3.2

--- a/charts/sync-bridge/README.md
+++ b/charts/sync-bridge/README.md
@@ -1,6 +1,6 @@
 # sync-bridge
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.1](https://img.shields.io/badge/AppVersion-0.3.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 A Helm chart for the SensRNet sync component between SensRNet registry back-end and MultiChain node
 


### PR DESCRIPTION
chore: Bump registry-sync from 0.3.1 to 0.4.0
- Hernoem "observation area" naar "observed area" (https://github.com/kadaster-labs/sensrnet-sync/pull/56)
- Event upcasting toegevoegd (https://github.com/kadaster-labs/sensrnet-sync/pull/56)
- Upgrade NestJS to v8 (https://github.com/kadaster-labs/sensrnet-sync/pull/57)
- Update base image to latest version (https://github.com/kadaster-labs/sensrnet-sync/pull/57)

chore: Bump registry-backend from 0.8.1 to 0.9.0
- Hernoem "observation area" naar "observed area" (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/146)
- Event upcasting toegevoegd (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/146)
- Upgrade NestJS to v8 (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/149)
- Update base image to latest version (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/149)

chore: Bump registry-frontend from 0.10.1 to 0.11.0
- Hernoem "observation area" naar "observed area" (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/194)
- Update base image to latest version (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/198)
- Update Socket.io version to match updated version in backend (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/198)
- Update NodeJS dependencies

chore: Bump central-viewer from 0.6.4 to 0.6.6
- Updated Nginx base image to latest version (https://github.com/kadaster-labs/sensrnet-central-viewer/pull/54)