### PR TITLE
chore: Bump component versions

### DIFF
--- a/charts/central-viewer/Chart.yaml
+++ b/charts/central-viewer/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.6.6
+appVersion: 0.6.7
 description: A Helm chart for the central viewer of SensRNet
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: central-viewer
 sources:
   - https://github.com/kadaster-labs/sensrnet-central-viewer
 type: application
-version: 0.4.4
+version: 0.4.5

--- a/charts/central-viewer/README.md
+++ b/charts/central-viewer/README.md
@@ -1,6 +1,6 @@
 # central-viewer
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
 
 A Helm chart for the central viewer of SensRNet
 

--- a/charts/registry-backend/Chart.yaml
+++ b/charts/registry-backend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.9.0
+appVersion: 0.9.1
 dependencies:
   - name: mongodb
     version: "10.6.0"
@@ -21,4 +21,4 @@ name: registry-backend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-backend
 type: application
-version: 0.6.4
+version: 0.6.5

--- a/charts/registry-backend/README.md
+++ b/charts/registry-backend/README.md
@@ -1,6 +1,6 @@
 # registry-backend
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.0](https://img.shields.io/badge/AppVersion-0.9.0-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.9.1](https://img.shields.io/badge/AppVersion-0.9.1-informational?style=flat-square)
 
 Helm charts for the SensRNet registry back-end
 

--- a/charts/registry-frontend/Chart.yaml
+++ b/charts/registry-frontend/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.11.0
+appVersion: 0.11.1
 description: A Helm chart for Kubernetes
 home: https://github.com/kadaster-labs/sensrnet-home
 icon: https://kadaster-labs.github.io/sensrnet-home/img/SensRNet-logo.png
@@ -12,4 +12,4 @@ name: registry-frontend
 sources:
   - https://github.com/kadaster-labs/sensrnet-registry-frontend
 type: application
-version: 0.6.4
+version: 0.6.5

--- a/charts/registry-frontend/README.md
+++ b/charts/registry-frontend/README.md
@@ -1,6 +1,6 @@
 # registry-frontend
 
-![Version: 0.6.4](https://img.shields.io/badge/Version-0.6.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.6.5](https://img.shields.io/badge/Version-0.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.1](https://img.shields.io/badge/AppVersion-0.11.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
chore: Bump central-viewer from 0.6.6 to 0.6.7

- fix: hide organization URL when not provided (https://github.com/kadaster-labs/sensrnet-central-viewer/pull/63)

chore: Bump registry-frontend from 0.11.0 to 0.11.1

- fix: no longer set name based on device category (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/214)
- fix: show correct error message (https://github.com/kadaster-labs/sensrnet-registry-frontend/pull/215)
  
chore: Bump registry-backend from 0.9.0 to 0.9.1

- fix: correctly remove deleted goal from multiple datastreams (https://github.com/kadaster-labs/sensrnet-registry-backend/pull/153)